### PR TITLE
fix: resolve antd reset css path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,9 +8,19 @@ export default defineConfig({
   base: '/needbox-web/',
   plugins: [react()],
   resolve: {
-    alias: {
-      antd: path.resolve(__dirname, 'src/antd-stubs.tsx')
-    }
+    alias: [
+      {
+        find: 'antd/dist/reset.css',
+        replacement: path.resolve(
+          __dirname,
+          'node_modules/antd/dist/reset.css'
+        )
+      },
+      {
+        find: 'antd',
+        replacement: path.resolve(__dirname, 'src/antd-stubs.tsx')
+      }
+    ]
   },
   test: {
     environment: 'jsdom'


### PR DESCRIPTION
## Summary
- alias Ant Design reset CSS to real package while stubbing JS components to allow Vite build

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899daf1e540832fa3c552e6f50191cc